### PR TITLE
fixing problems with the way the Luminus template works. NOTE: adding…

### DIFF
--- a/dev-config.edn
+++ b/dev-config.edn
@@ -1,0 +1,10 @@
+;; WARNING
+;; The dev-config.edn file is used for local environment variables, such as database credentials.
+;; This file is listed in .gitignore and will be excluded from version control by Git.
+
+{:dev true
+ :port 3000
+ ;; when :nrepl-port is set the application starts the nREPL server on load
+ :nrepl-port 7000
+ 
+ }

--- a/env/dev/clj/user.clj
+++ b/env/dev/clj/user.clj
@@ -4,7 +4,7 @@
     [clojure.spec.alpha :as s]
     [expound.alpha :as expound]
     [mount.core :as mount]
-    [sample-1.figwheel :refer [start-fw stop-fw cljs]]
+    ;[sample-1.figwheel :refer [start-fw stop-fw cljs]]
     [sample-1.core :refer [start-app]]))
 
 (alter-var-root #'s/*explain-out* (constantly expound/printer))


### PR DESCRIPTION
… dev-config.edn to a repository is actually pretty dangerous given what could be stored in it, but for this simple example it makes the samples tasks much easier.